### PR TITLE
Fix RecipesService test import

### DIFF
--- a/src/app/core/services/recipes.service.spec.ts
+++ b/src/app/core/services/recipes.service.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 
-import { Recipes } from './recipes.service';
+import { RecipesService } from './recipes.service';
 
-describe('Recipes', () => {
-  let service: Recipes;
+describe('RecipesService', () => {
+  let service: RecipesService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
-    service = TestBed.inject(Recipes);
+    service = TestBed.inject(RecipesService);
   });
 
   it('should be created', () => {


### PR DESCRIPTION
## Summary
- fix import and describe block in RecipesService unit test

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b2cf5dac83229c1e66dcd062595c