### PR TITLE
Add detailed recipe page

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,12 +1,18 @@
 import { Routes } from '@angular/router';
 import { HomePage } from './features/home/home-page/home-page';
 import { RegisterPage } from './features/register/register-page/register-page';
+import { RecipePage } from './features/recipe/recipe-page/recipe-page';
 import { authGuard } from './core/guards/auth-guard';
 
 export const routes: Routes = [
   {
     path: '',
     component: HomePage,
+    canActivate: [authGuard],
+  },
+  {
+    path: 'recipe/:id',
+    component: RecipePage,
     canActivate: [authGuard],
   },
   {

--- a/src/app/core/services/recipes.service.ts
+++ b/src/app/core/services/recipes.service.ts
@@ -53,6 +53,22 @@ export class RecipesService {
   public readonly categoriesselected = signal<string | null>(null);
   public readonly searchResults = signal<RecipeDetailed[] | null>(null);
 
+  /** Signal pour l'identifiant de la recette sélectionnée */
+  public readonly currentRecipeId = signal<string | null>(null);
+
+  /** Resource pour récupérer le détail d'une recette */
+  public readonly recipeResource = resource({
+    params: () => ({ id: this.currentRecipeId() }),
+    loader: ({ params }) => {
+      if (!params.id) return Promise.resolve(null);
+      return firstValueFrom(
+        this.http.get<{ meals: RecipeDetailed[] | null }>(
+          `https://www.themealdb.com/api/json/v1/1/lookup.php?i=${params.id}`
+        )
+      ).then(res => (res.meals ? res.meals[0] : null));
+    }
+  });
+
   //
   // 2.2. Resource pour récupérer les recettes d’une catégorie donnée.
   //      On passe en générique <string, RecipeSummary[]> :
@@ -110,6 +126,11 @@ export class RecipesService {
 
   setCurrentCategory(categoryName: string | null): void {
     this.categoriesselected.set(categoryName);
+  }
+
+  /** Définit l'identifiant de la recette à afficher */
+  setCurrentRecipeId(id: string | null): void {
+    this.currentRecipeId.set(id);
   }
 
   /** Lance la requête search.php?s=… et met à jour searchResults */

--- a/src/app/features/home/components/DetailedRecipeCard/DetailedRecipeCard.html
+++ b/src/app/features/home/components/DetailedRecipeCard/DetailedRecipeCard.html
@@ -1,4 +1,4 @@
-<mat-card class="detailed-recipe-card">
+<mat-card class="detailed-recipe-card" [routerLink]="['/recipe', recipe.idMeal]">
     <mat-card-header>
         <mat-card-title>{{ recipe.strMeal }}</mat-card-title>
         <mat-card-subtitle>

--- a/src/app/features/home/components/DetailedRecipeCard/DetailedRecipeCard.ts
+++ b/src/app/features/home/components/DetailedRecipeCard/DetailedRecipeCard.ts
@@ -3,11 +3,12 @@ import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatListModule } from '@angular/material/list';
 import { RecipeDetailed } from '../../../../core/services/recipes.service';
+import { RouterModule } from '@angular/router';
 
 @Component({
     selector: 'app-detailed-recipe-card',
     standalone: true,
-    imports: [CommonModule, MatCardModule, MatListModule],
+    imports: [CommonModule, MatCardModule, MatListModule, RouterModule],
     templateUrl: './DetailedRecipeCard.html',
     styleUrls: ['./DetailedRecipeCard.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/app/features/home/components/recipe-card/recipe-card.html
+++ b/src/app/features/home/components/recipe-card/recipe-card.html
@@ -1,4 +1,4 @@
-<mat-card class="recipe-card">
+<mat-card class="recipe-card" [routerLink]="['/recipe', recipe.idMeal]">
   <img mat-card-image [src]="recipe.strMealThumb" [alt]="recipe.strMeal" />
   <mat-card-content>
     <h4 class="recipe-title">{{ recipe.strMeal }}</h4>

--- a/src/app/features/home/components/recipe-card/recipe-card.ts
+++ b/src/app/features/home/components/recipe-card/recipe-card.ts
@@ -2,6 +2,7 @@ import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
+import { RouterModule } from '@angular/router';
 
 export interface RecipeSummary {
   idMeal: string;
@@ -12,7 +13,7 @@ export interface RecipeSummary {
 @Component({
   selector: 'app-recipe-card',
   standalone: true,
-  imports: [CommonModule, MatCardModule, MatButtonModule],
+  imports: [CommonModule, MatCardModule, MatButtonModule, RouterModule],
   templateUrl: './recipe-card.html',
   styleUrls: ['./recipe-card.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush

--- a/src/app/features/recipe/recipe-page/recipe-page.html
+++ b/src/app/features/recipe/recipe-page/recipe-page.html
@@ -1,0 +1,29 @@
+<app-page-layout>
+  <ng-container *ngIf="recipeResource.value() as recipe; else loading">
+    <header class="recipe-header">
+      <h1>{{ recipe.strMeal }}</h1>
+      <p>{{ recipe.strCategory }} - {{ recipe.strArea }}</p>
+      <a *ngIf="recipe.strSource" [href]="recipe.strSource" target="_blank">Source</a>
+    </header>
+
+    <mat-card>
+      <img mat-card-image [src]="recipe.strMealThumb" [alt]="recipe.strMeal" />
+      <mat-card-content>
+        <h2>Ingrédients</h2>
+        <mat-list>
+          <mat-list-item *ngFor="let i of getIngredients(recipe)">{{ i }}</mat-list-item>
+        </mat-list>
+
+        <div class="video" *ngIf="recipe.strYoutube">
+          <a [href]="recipe.strYoutube" target="_blank">Voir la vidéo</a>
+        </div>
+
+        <h2>Instructions</h2>
+        <p>{{ recipe.strInstructions }}</p>
+      </mat-card-content>
+    </mat-card>
+  </ng-container>
+  <ng-template #loading>
+    <p>Chargement...</p>
+  </ng-template>
+</app-page-layout>

--- a/src/app/features/recipe/recipe-page/recipe-page.scss
+++ b/src/app/features/recipe/recipe-page/recipe-page.scss
@@ -1,0 +1,6 @@
+.recipe-header {
+  margin-bottom: 16px;
+  h1 { margin: 0; }
+  a { margin-top: 4px; display: inline-block; }
+}
+.video { margin: 16px 0; }

--- a/src/app/features/recipe/recipe-page/recipe-page.spec.ts
+++ b/src/app/features/recipe/recipe-page/recipe-page.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RecipePage } from './recipe-page';
+
+describe('RecipePage', () => {
+  let component: RecipePage;
+  let fixture: ComponentFixture<RecipePage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RecipePage]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RecipePage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/recipe/recipe-page/recipe-page.ts
+++ b/src/app/features/recipe/recipe-page/recipe-page.ts
@@ -1,0 +1,37 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute } from '@angular/router';
+import { PageLayoutComponent } from '../../../shared/layouts/page-layout/page-layout.component';
+import { RecipesService, RecipeDetailed } from '../../../core/services/recipes.service';
+import { MatCardModule } from '@angular/material/card';
+import { MatListModule } from '@angular/material/list';
+
+@Component({
+  selector: 'app-recipe-page',
+  standalone: true,
+  imports: [CommonModule, PageLayoutComponent, MatCardModule, MatListModule],
+  templateUrl: './recipe-page.html',
+  styleUrl: './recipe-page.scss'
+})
+export class RecipePage {
+  private readonly route = inject(ActivatedRoute);
+  private readonly recipesService = inject(RecipesService);
+
+  recipeResource = this.recipesService.recipeResource;
+
+  constructor() {
+    const id = this.route.snapshot.paramMap.get('id');
+    this.recipesService.setCurrentRecipeId(id);
+  }
+
+  getIngredients(recipe: RecipeDetailed | null): string[] {
+    if (!recipe) return [];
+    const items: string[] = [];
+    for (let i = 1; i <= 20; i++) {
+      const ing = recipe[`strIngredient${i}`]?.trim();
+      const qty = recipe[`strMeasure${i}`]?.trim();
+      if (ing) items.push(qty ? `${ing} – ${qty}` : ing);
+    }
+    return items;
+  }
+}


### PR DESCRIPTION
## Summary
- add route `/recipe/:id`
- create `RecipePage` to display full recipe details
- update `RecipesService` with `recipeResource`
- enable navigation from recipe cards to the new page

## Testing
- `npm test --silent -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b69d0ab0832288dbe2acd389e048