### PR TITLE
Add hover-play directive for YouTube iframe

### DIFF
--- a/src/app/features/recipe/recipe-page/recipe-page.html
+++ b/src/app/features/recipe/recipe-page/recipe-page.html
@@ -15,7 +15,15 @@
         </mat-list>
 
         <div class="video" *ngIf="recipe['strYoutube']">
-          <a [href]="recipe['strYoutube']" target="_blank">Voir la vidéo</a>
+          <iframe
+            width="560"
+            height="315"
+            [src]="getYoutubeUrl(recipe)"
+            frameborder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowfullscreen
+            appYTHoverPlay>
+          </iframe>
         </div>
 
         <h2>Instructions</h2>

--- a/src/app/features/recipe/recipe-page/recipe-page.ts
+++ b/src/app/features/recipe/recipe-page/recipe-page.ts
@@ -5,17 +5,26 @@ import { PageLayoutComponent } from '../../../shared/layouts/page-layout/page-la
 import { RecipesService, RecipeDetailed } from '../../../core/services/recipes.service';
 import { MatCardModule } from '@angular/material/card';
 import { MatListModule } from '@angular/material/list';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { YtHoverPlayDirective } from '../../../shared/directives/yt-hover-play.directive';
 
 @Component({
   selector: 'app-recipe-page',
   standalone: true,
-  imports: [CommonModule, PageLayoutComponent, MatCardModule, MatListModule],
+  imports: [
+    CommonModule,
+    PageLayoutComponent,
+    MatCardModule,
+    MatListModule,
+    YtHoverPlayDirective
+  ],
   templateUrl: './recipe-page.html',
   styleUrl: './recipe-page.scss'
 })
 export class RecipePage {
   private readonly route = inject(ActivatedRoute);
   private readonly recipesService = inject(RecipesService);
+  private readonly sanitizer = inject(DomSanitizer);
 
   recipeResource = this.recipesService.recipeResource;
 
@@ -33,5 +42,19 @@ export class RecipePage {
       if (ing) items.push(qty ? `${ing} – ${qty}` : ing);
     }
     return items;
+  }
+
+  getYoutubeUrl(recipe: RecipeDetailed | null): SafeResourceUrl | null {
+    if (!recipe || !recipe['strYoutube']) return null;
+    try {
+      const url = new URL(recipe['strYoutube']);
+      const id = url.searchParams.get('v');
+      if (!id) return null;
+      return this.sanitizer.bypassSecurityTrustResourceUrl(
+        `https://www.youtube.com/embed/${id}?enablejsapi=1`
+      );
+    } catch {
+      return null;
+    }
   }
 }

--- a/src/app/shared/directives/yt-hover-play.directive.spec.ts
+++ b/src/app/shared/directives/yt-hover-play.directive.spec.ts
@@ -1,0 +1,10 @@
+import { ElementRef } from '@angular/core';
+import { YtHoverPlayDirective } from './yt-hover-play.directive';
+
+describe('YtHoverPlayDirective', () => {
+  it('should create an instance', () => {
+    const el = new ElementRef<HTMLIFrameElement>(document.createElement('iframe'));
+    const directive = new YtHoverPlayDirective(el);
+    expect(directive).toBeTruthy();
+  });
+});

--- a/src/app/shared/directives/yt-hover-play.directive.ts
+++ b/src/app/shared/directives/yt-hover-play.directive.ts
@@ -1,0 +1,26 @@
+import { Directive, ElementRef, HostListener } from '@angular/core';
+
+@Directive({
+  selector: 'iframe[appYTHoverPlay]',
+  standalone: true
+})
+export class YtHoverPlayDirective {
+  constructor(private readonly el: ElementRef<HTMLIFrameElement>) {}
+
+  @HostListener('mouseenter')
+  play(): void {
+    this.postMessage('playVideo');
+  }
+
+  @HostListener('mouseleave')
+  pause(): void {
+    this.postMessage('pauseVideo');
+  }
+
+  private postMessage(command: string): void {
+    this.el.nativeElement.contentWindow?.postMessage(
+      JSON.stringify({ event: 'command', func: command, args: [] }),
+      '*'
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `YtHoverPlayDirective` to autoplay/pause a YouTube iframe on hover
- embed YouTube video on `RecipePage` and use the new directive
- compute and sanitize YouTube embed URL
- test directive creation

## Testing
- `npx ng test --watch=false` *(fails: 403 Forbidden while trying to download ng)*

------
https://chatgpt.com/codex/tasks/task_e_6849b9d86f048322bb3e4ecacedea1a5