### PR TITLE
Add diet detector pipe

### DIFF
--- a/src/app/features/recipe/recipe-page/recipe-page.html
+++ b/src/app/features/recipe/recipe-page/recipe-page.html
@@ -2,7 +2,10 @@
   <ng-container *ngIf="recipeResource.value() as recipe; else loading">
     <header class="recipe-header">
       <h1>{{ recipe.strMeal }}</h1>
-      <p>{{ recipe.strCategory }} - {{ recipe.strArea }}</p>
+      <p>
+        {{ recipe.strCategory }} - {{ recipe.strArea }}
+        <span class="diet-badge">{{ recipe | dietDetector }}</span>
+      </p>
       <a *ngIf="recipe['strSource']" [href]="recipe['strSource']" target="_blank">Source</a>
     </header>
 

--- a/src/app/features/recipe/recipe-page/recipe-page.scss
+++ b/src/app/features/recipe/recipe-page/recipe-page.scss
@@ -4,3 +4,11 @@
   a { margin-top: 4px; display: inline-block; }
 }
 .video { margin: 16px 0; }
+
+.diet-badge {
+  margin-left: 8px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background-color: #e0e0e0;
+  font-size: 0.75rem;
+}

--- a/src/app/features/recipe/recipe-page/recipe-page.ts
+++ b/src/app/features/recipe/recipe-page/recipe-page.ts
@@ -7,6 +7,7 @@ import { MatCardModule } from '@angular/material/card';
 import { MatListModule } from '@angular/material/list';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { YtHoverPlayDirective } from '../../../shared/directives/yt-hover-play.directive';
+import { DietDetectorPipe } from '../../../shared/pipes/diet-detector.pipe';
 
 @Component({
   selector: 'app-recipe-page',
@@ -16,7 +17,8 @@ import { YtHoverPlayDirective } from '../../../shared/directives/yt-hover-play.d
     PageLayoutComponent,
     MatCardModule,
     MatListModule,
-    YtHoverPlayDirective
+    YtHoverPlayDirective,
+    DietDetectorPipe
   ],
   templateUrl: './recipe-page.html',
   styleUrl: './recipe-page.scss'

--- a/src/app/shared/pipes/diet-detector.pipe.spec.ts
+++ b/src/app/shared/pipes/diet-detector.pipe.spec.ts
@@ -1,0 +1,35 @@
+import { DietDetectorPipe } from './diet-detector.pipe';
+import { RecipeDetailed } from '../../core/services/recipes.service';
+
+describe('DietDetectorPipe', () => {
+  const pipe = new DietDetectorPipe();
+
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('detects classic recipes', () => {
+    const recipe = {
+      strIngredient1: 'Beef',
+      strIngredient2: 'Onion'
+    } as RecipeDetailed;
+    expect(pipe.transform(recipe)).toBe('Classic');
+  });
+
+  it('detects vegetarian recipes', () => {
+    const recipe = {
+      strIngredient1: 'Egg',
+      strIngredient2: 'Milk',
+      strIngredient3: 'Flour'
+    } as RecipeDetailed;
+    expect(pipe.transform(recipe)).toBe('Vegetarian');
+  });
+
+  it('detects vegan recipes', () => {
+    const recipe = {
+      strIngredient1: 'Carrot',
+      strIngredient2: 'Potato'
+    } as RecipeDetailed;
+    expect(pipe.transform(recipe)).toBe('Vegan');
+  });
+});

--- a/src/app/shared/pipes/diet-detector.pipe.ts
+++ b/src/app/shared/pipes/diet-detector.pipe.ts
@@ -1,0 +1,44 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { RecipeDetailed } from '../../core/services/recipes.service';
+
+@Pipe({
+  name: 'dietDetector',
+  standalone: true
+})
+export class DietDetectorPipe implements PipeTransform {
+  transform(recipe: RecipeDetailed | null): string {
+    if (!recipe) return '';
+
+    const ingredients: string[] = [];
+    for (let i = 1; i <= 20; i++) {
+      const ing = recipe[`strIngredient${i}`];
+      if (typeof ing === 'string' && ing.trim()) {
+        ingredients.push(ing.trim().toLowerCase());
+      }
+    }
+
+    const meatKeywords = [
+      'beef', 'pork', 'chicken', 'turkey', 'lamb', 'mutton', 'bacon',
+      'ham', 'duck', 'meat', 'anchovy', 'anchovies', 'fish', 'tuna',
+      'salmon', 'shrimp', 'prawn', 'crab', 'lobster'
+    ];
+    const nonVeganKeywords = [
+      'egg', 'eggs', 'milk', 'cheese', 'butter', 'cream', 'yogurt',
+      'yoghurt', 'honey'
+    ];
+
+    const hasMeat = ingredients.some(ing =>
+      meatKeywords.some(k => ing.includes(k))
+    );
+
+    if (hasMeat) return 'Classic';
+
+    const hasNonVegan = ingredients.some(ing =>
+      nonVeganKeywords.some(k => ing.includes(k))
+    );
+
+    if (hasNonVegan) return 'Vegetarian';
+
+    return 'Vegan';
+  }
+}


### PR DESCRIPTION
## Summary
- detect diet type from recipe using a new `dietDetector` pipe
- display diet badge in recipe header
- import pipe in `RecipePage`
- style badge in recipe page header
- add unit tests for the pipe

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849bdea687c8322a69c2fcd12265e5a