### PR TITLE
Add favorites feature

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { HomePage } from './features/home/home-page/home-page';
 import { RegisterPage } from './features/register/register-page/register-page';
 import { RecipePage } from './features/recipe/recipe-page/recipe-page';
+import { FavoritesPage } from './features/favorites/favorites-page/favorites-page';
 import { authGuard } from './core/guards/auth-guard';
 
 export const routes: Routes = [
@@ -13,6 +14,11 @@ export const routes: Routes = [
   {
     path: 'recipe/:id',
     component: RecipePage,
+    canActivate: [authGuard],
+  },
+  {
+    path: 'favorites',
+    component: FavoritesPage,
     canActivate: [authGuard],
   },
   {

--- a/src/app/core/services/favorites.service.ts
+++ b/src/app/core/services/favorites.service.ts
@@ -1,0 +1,49 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class FavoritesService {
+  private readonly STORAGE_KEY = 'favorite_recipes';
+
+  private _favorites = signal<string[]>(this.loadFromStorage());
+  /** Liste des identifiants de recettes favoris */
+  favorites = this._favorites;
+
+  private loadFromStorage(): string[] {
+    const raw = localStorage.getItem(this.STORAGE_KEY);
+    try {
+      return raw ? JSON.parse(raw) : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private saveToStorage(): void {
+    localStorage.setItem(this.STORAGE_KEY, JSON.stringify(this._favorites()));
+  }
+
+  add(id: string): void {
+    if (!this._favorites().includes(id)) {
+      this._favorites.set([...this._favorites(), id]);
+      this.saveToStorage();
+    }
+  }
+
+  remove(id: string): void {
+    if (this._favorites().includes(id)) {
+      this._favorites.set(this._favorites().filter(f => f !== id));
+      this.saveToStorage();
+    }
+  }
+
+  toggle(id: string): void {
+    if (this.isFavorite(id)) {
+      this.remove(id);
+    } else {
+      this.add(id);
+    }
+  }
+
+  isFavorite(id: string): boolean {
+    return this._favorites().includes(id);
+  }
+}

--- a/src/app/features/favorites/favorites-page/favorites-page.html
+++ b/src/app/features/favorites/favorites-page/favorites-page.html
@@ -1,0 +1,15 @@
+<app-page-layout>
+  <h2>Mes recettes favorites</h2>
+
+  <ng-container *ngIf="favoriteIds().length; else emptyList">
+    <mat-progress-spinner *ngIf="loading()" mode="indeterminate"></mat-progress-spinner>
+    <app-detailed-recipe-card
+      *ngFor="let recipe of recipes()"
+      [recipe]="recipe">
+    </app-detailed-recipe-card>
+  </ng-container>
+
+  <ng-template #emptyList>
+    <p>Aucune recette favorite pour le moment.</p>
+  </ng-template>
+</app-page-layout>

--- a/src/app/features/favorites/favorites-page/favorites-page.scss
+++ b/src/app/features/favorites/favorites-page/favorites-page.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/src/app/features/favorites/favorites-page/favorites-page.ts
+++ b/src/app/features/favorites/favorites-page/favorites-page.ts
@@ -1,0 +1,37 @@
+import { Component, effect, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PageLayoutComponent } from '../../shared/layouts/page-layout/page-layout.component';
+import { FavoritesService } from '../../core/services/favorites.service';
+import { RecipesService, RecipeDetailed } from '../../core/services/recipes.service';
+import { DetailedRecipeCardComponent } from '../home/components/DetailedRecipeCard/DetailedRecipeCard';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+@Component({
+  selector: 'app-favorites-page',
+  standalone: true,
+  imports: [CommonModule, PageLayoutComponent, DetailedRecipeCardComponent, MatProgressSpinnerModule],
+  templateUrl: './favorites-page.html',
+  styleUrl: './favorites-page.scss'
+})
+export class FavoritesPage {
+  private favoritesService = inject(FavoritesService);
+  private recipesService = inject(RecipesService);
+
+  favoriteIds = this.favoritesService.favorites;
+  recipes = signal<RecipeDetailed[]>([]);
+  loading = signal(false);
+
+  constructor() {
+    effect(() => {
+      const ids = this.favoriteIds();
+      if (!ids.length) {
+        this.recipes.set([]);
+        return;
+      }
+      this.loading.set(true);
+      Promise.all(ids.map(id => this.recipesService.getRecipeById(id)))
+        .then(list => this.recipes.set(list.filter((r): r is RecipeDetailed => !!r)))
+        .finally(() => this.loading.set(false));
+    });
+  }
+}

--- a/src/app/features/home/components/DetailedRecipeCard/DetailedRecipeCard.html
+++ b/src/app/features/home/components/DetailedRecipeCard/DetailedRecipeCard.html
@@ -14,4 +14,9 @@
         <h4>Instructions</h4>
         <p>{{ recipe.strInstructions }}</p>
     </mat-card-content>
+    <mat-card-actions>
+        <button mat-icon-button color="warn" (click)="toggleFavorite($event)" aria-label="Ajouter aux favoris">
+            <mat-icon>{{ isFavorite() ? 'favorite' : 'favorite_border' }}</mat-icon>
+        </button>
+    </mat-card-actions>
 </mat-card>

--- a/src/app/features/home/components/DetailedRecipeCard/DetailedRecipeCard.ts
+++ b/src/app/features/home/components/DetailedRecipeCard/DetailedRecipeCard.ts
@@ -1,20 +1,35 @@
-import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Input, ChangeDetectionStrategy, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatListModule } from '@angular/material/list';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 import { RecipeDetailed } from '../../../../core/services/recipes.service';
 import { RouterModule } from '@angular/router';
+import { FavoritesService } from '../../../../core/services/favorites.service';
 
 @Component({
     selector: 'app-detailed-recipe-card',
     standalone: true,
-    imports: [CommonModule, MatCardModule, MatListModule, RouterModule],
+    imports: [CommonModule, MatCardModule, MatListModule, MatButtonModule, MatIconModule, RouterModule],
     templateUrl: './DetailedRecipeCard.html',
     styleUrls: ['./DetailedRecipeCard.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DetailedRecipeCardComponent {
     @Input({ required: true }) recipe!: RecipeDetailed;
+
+    private favoritesService = inject(FavoritesService);
+
+    isFavorite(): boolean {
+        return this.favoritesService.isFavorite(this.recipe.idMeal);
+    }
+
+    toggleFavorite(event: Event): void {
+        event.preventDefault();
+        event.stopPropagation();
+        this.favoritesService.toggle(this.recipe.idMeal);
+    }
 
     /** Extrait ingrédients + mesures */
     getIngredients(): string[] {

--- a/src/app/features/home/components/recipe-card/recipe-card.html
+++ b/src/app/features/home/components/recipe-card/recipe-card.html
@@ -3,9 +3,9 @@
   <mat-card-content>
     <h4 class="recipe-title">{{ recipe.strMeal }}</h4>
   </mat-card-content>
-  <!-- Si on veut ajouter un bouton "Voir plus", on peut décommenter :
   <mat-card-actions>
-    <button mat-button color="primary">Voir la fiche</button>
+    <button mat-icon-button color="warn" (click)="toggleFavorite($event)" aria-label="Ajouter aux favoris">
+      <mat-icon>{{ isFavorite() ? 'favorite' : 'favorite_border' }}</mat-icon>
+    </button>
   </mat-card-actions>
-  -->
 </mat-card>

--- a/src/app/features/home/components/recipe-card/recipe-card.ts
+++ b/src/app/features/home/components/recipe-card/recipe-card.ts
@@ -1,8 +1,10 @@
-import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Input, ChangeDetectionStrategy, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 import { RouterModule } from '@angular/router';
+import { FavoritesService } from '../../../../core/services/favorites.service';
 
 export interface RecipeSummary {
   idMeal: string;
@@ -13,11 +15,23 @@ export interface RecipeSummary {
 @Component({
   selector: 'app-recipe-card',
   standalone: true,
-  imports: [CommonModule, MatCardModule, MatButtonModule, RouterModule],
+  imports: [CommonModule, MatCardModule, MatButtonModule, MatIconModule, RouterModule],
   templateUrl: './recipe-card.html',
   styleUrls: ['./recipe-card.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class RecipeCardComponent {
   @Input({ required: true }) recipe!: RecipeSummary;
+
+  private favoritesService = inject(FavoritesService);
+
+  isFavorite(): boolean {
+    return this.favoritesService.isFavorite(this.recipe.idMeal);
+  }
+
+  toggleFavorite(event: Event): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.favoritesService.toggle(this.recipe.idMeal);
+  }
 }

--- a/src/app/shared/layouts/page-layout/page-layout.component.html
+++ b/src/app/shared/layouts/page-layout/page-layout.component.html
@@ -1,9 +1,7 @@
 <mat-toolbar color="primary" class="app-toolbar">
   <span class="logo">CookingBuddy</span>
-  <!--
-    Vous pouvez ajouter ici des <button mat-button routerLink="/quelque-chose">Lien</button>
-    pour vos futures pages.
-  -->
+  <!-- Liens de navigation -->
+  <button mat-button routerLink="/favorites">Favoris</button>
   <span class="spacer"></span>
 </mat-toolbar>
 


### PR DESCRIPTION
## Summary
- create `FavoritesService` for storing favorite recipes in localStorage
- add `FavoritesPage` to list favorite recipes
- display heart buttons on recipe cards to toggle favorites
- add navigation link to favorites in toolbar
- route `/favorites` protected by `authGuard`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849bfa4bce08322923ac80be6d103e1